### PR TITLE
Fix code scanning alert no. 2: Multiplication result converted to larger type

### DIFF
--- a/src/third-party/imgui/imstb_truetype.h
+++ b/src/third-party/imgui/imstb_truetype.h
@@ -4616,7 +4616,7 @@ STBTT_DEF unsigned char * stbtt_GetGlyphSDF(const stbtt_fontinfo *info, float sc
       float *precompute;
       stbtt_vertex *verts;
       int num_verts = stbtt_GetGlyphShape(info, glyph, &verts);
-      data = (unsigned char *) STBTT_malloc(w * h, info->userdata);
+      data = (unsigned char *) STBTT_malloc((size_t)w * h, info->userdata);
       precompute = (float *) STBTT_malloc(num_verts * sizeof(float), info->userdata);
 
       for (i=0,j=num_verts-1; i < num_verts; j=i++) {


### PR DESCRIPTION
Fixes [https://github.com/aka2024/Cataclysm-DDA/security/code-scanning/2](https://github.com/aka2024/Cataclysm-DDA/security/code-scanning/2)

_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
