### PR TITLE
Fix code scanning alert no. 18: Multiplication result converted to larger type

### DIFF
--- a/src/melee.cpp
+++ b/src/melee.cpp
@@ -1040,7 +1040,7 @@ void Character::reach_attack( const tripoint &p, int forced_movecost )
         Creature *inter = creatures.creature_at( path_point );
         /** @EFFECT_MELEE decreases chance of hitting intervening target on reach attack */
         if( inter != nullptr &&
-            !x_in_y( ( target_size * target_size + 1 ) * skill,
+            !x_in_y( ( static_cast<float>(target_size) * target_size + 1 ) * skill,
                      ( inter->get_size() * inter->get_size() + 1 ) * 10 ) ) {
             // Even if we miss here, low roll means weapon is pushed away or something like that
             if( inter->has_effect( effect_pet ) || ( inter->is_npc() &&


### PR DESCRIPTION
Fixes [https://github.com/aka2024/Cataclysm-DDA/security/code-scanning/18](https://github.com/aka2024/Cataclysm-DDA/security/code-scanning/18)

To fix the problem, we need to ensure that the multiplication is performed using a larger type to avoid overflow. Specifically, we should cast `target_size` to a `float` before performing the multiplication. This ensures that the multiplication is done in the `float` type, preventing overflow.

- Cast `target_size` to `float` before performing the multiplication.
- This change should be made on line 1043 in the file `src/melee.cpp`.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
