### PR TITLE
Fix code scanning alert no. 9: Multiplication result converted to larger type

### DIFF
--- a/src/third-party/imtui/imtui.h
+++ b/src/third-party/imtui/imtui.h
@@ -41,7 +41,7 @@ struct TScreen {
 
     inline void clear() {
         if (data) {
-            memset(data, 0, nx*ny*sizeof(TCell));
+            memset(data, 0, static_cast<size_t>(nx)*ny*sizeof(TCell));
         }
     }
 


### PR DESCRIPTION
Fixes [https://github.com/aka2024/Cataclysm-DDA/security/code-scanning/9](https://github.com/aka2024/Cataclysm-DDA/security/code-scanning/9)

To fix the problem, we need to ensure that the multiplication is performed using a larger integer type to prevent overflow. This can be achieved by casting one of the operands to `size_t` before performing the multiplication. This way, the multiplication will be done in the larger type, and the result will be correctly passed to `memset`.

The specific change involves casting `nx` to `size_t` before multiplying it by `ny` in the `clear` method. This change should be made in the file `src/third-party/imtui/imtui.h` on line 44.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
