### PR TITLE
Fix code scanning alert no. 8: Multiplication result converted to larger type

### DIFF
--- a/src/third-party/imgui/imgui_widgets.cpp
+++ b/src/third-party/imgui/imgui_widgets.cpp
@@ -2849,7 +2849,7 @@ TYPE ImGui::ScaleValueFromRatioT(ImGuiDataType data_type, float t, TYPE v_min, T
             //   This code is carefully tuned to work with large values (e.g. high ranges of U64) while preserving this property..
             // - Not doing a *1.0 multiply at the end of a range as it tends to be lossy. While absolute aiming at a large s64/u64
             //   range is going to be imprecise anyway, with this check we at least make the edge values matches expected limits.
-            FLOATTYPE v_new_off_f = (SIGNEDTYPE)(v_max - v_min) * t;
+            FLOATTYPE v_new_off_f = (FLOATTYPE)(v_max - v_min) * t;
             result = (TYPE)((SIGNEDTYPE)v_min + (SIGNEDTYPE)(v_new_off_f + (FLOATTYPE)(v_min > v_max ? -0.5 : 0.5)));
         }
     }


### PR DESCRIPTION
Fixes [https://github.com/aka2024/Cataclysm-DDA/security/code-scanning/8](https://github.com/aka2024/Cataclysm-DDA/security/code-scanning/8)

To fix the problem, we need to ensure that the multiplication is performed using the larger type to avoid overflow. This can be achieved by casting the operands to the larger type before performing the multiplication. Specifically, we should cast `v_max - v_min` to `FLOATTYPE` before multiplying by `t`.

- **General fix:** Cast the operands to the larger type before performing the multiplication.
- **Detailed fix:** In the file `src/third-party/imgui/imgui_widgets.cpp`, on line 2852, cast `v_max - v_min` to `FLOATTYPE` before multiplying by `t`.
- **Specific changes:** Modify line 2852 to cast `v_max - v_min` to `FLOATTYPE` before the multiplication.
- **Requirements:** No additional methods, imports, or definitions are needed.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
